### PR TITLE
Release v1.0.0: Full Support for Jupyter Environments (Fixes #1)

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,4 +24,4 @@ install:
   - py -m pip install tox
 
 test_script:
-  - py -m tox
+  - py -m tox -e %TOXENV%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,12 +1,22 @@
 image:
   - Visual Studio 2019
 
+# Only build main branch and tags
+branches:
+  only:
+    - main
+    - /v\d+\.\d+\.\d+/
+
 environment:
   matrix:
-  - TOXENV: py37
-  - TOXENV: py38
-  - TOXENV: py39
+  - TOXENV: py314
+  - TOXENV: py313
+  - TOXENV: py312
+  - TOXENV: py311
   - TOXENV: py310
+  - TOXENV: py39
+  - TOXENV: py38
+  - TOXENV: py37
 
 build: off
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,9 @@ authors = [
 keywords = ['input', 'stdin', 'timeout', 'console']
 classifiers = [
     'Programming Language :: Python :: 3',
+    'Programming Language :: Python :: 3.14',
+    'Programming Language :: Python :: 3.13',
+    'Programming Language :: Python :: 3.12',
     'Programming Language :: Python :: 3.11',
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.9',
@@ -40,6 +43,9 @@ legacy_tox_ini = """
     [tox]
     min_version = 4.0
     env_list =
+        py314
+        py313
+        py312
         py311
         py310
         py39

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "timedinput"
-version = "0.1.2"
+version = "1.0.0"
 description = "Timeout for python inputs"
 readme = "README.md"
 license = {file = "LICENSE"}
@@ -31,6 +31,9 @@ classifiers = [
 [project.urls]
 "Source" = "https://github.com/kerollosy/timedinput"
 "Bug Tracker" = "https://github.com/kerollosy/timedinput/issues"
+
+[project.optional-dependencies]
+jupyter = ["ipywidgets", "jupyter-ui-poll"]
 
 [tool.tox]
 legacy_tox_ini = """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ jupyter = ["ipywidgets", "jupyter-ui-poll"]
 legacy_tox_ini = """
     [tox]
     min_version = 4.0
+    skip_missing_interpreters = true
     env_list =
         py314
         py313

--- a/timedinput/timedinput.py
+++ b/timedinput/timedinput.py
@@ -1,9 +1,9 @@
 """Timeout for python inputs"""
 
 import sys
+import time
 
 if sys.platform.startswith("win"):
-    import time
     import msvcrt
 else:
     import selectors
@@ -28,6 +28,57 @@ def echo(string):
     """Prints a string"""
     sys.stdout.write(string)
     sys.stdout.flush()
+
+def is_jupyter():
+    """Detects if the code is running inside a Jupyter Notebook, Google Colab, or IPython."""
+    if 'google.colab' in sys.modules:
+        return True
+    
+    try:
+        shell = get_ipython().__class__.__name__
+        if shell in ('ZMQInteractiveShell', 'Shell'):
+            return True
+        return False
+    except NameError:
+        return False
+
+def jupyter_timedinput(prompt='', timeout=DEFAULT_TIMEOUT, default=None):
+    """Timed input for Jupyter using jupyter_ui_poll."""
+    import ipywidgets as widgets
+    from IPython.display import display
+    from jupyter_ui_poll import ui_events
+
+    result = [None]
+    done = [False]
+
+    label = widgets.Label(value=prompt)
+    text = widgets.Text(placeholder='Type and press Enter...')
+    box = widgets.VBox([label, text])
+
+    def on_submit(widget):
+        result[0] = widget.value
+        done[0] = True
+
+    text.on_submit(on_submit)
+    display(box)
+
+    start_time = time.monotonic()
+
+    with ui_events() as poll:
+        while not done[0]:
+            poll(10)
+            if time.monotonic() - start_time > timeout:
+                break
+            time.sleep(0.05)
+
+    box.close()
+
+    if not done[0]:
+        if default is not None:
+            return default
+        raise TimeoutOccurred
+
+    return result[0]
 
 
 def posix_timedinput(prompt='', timeout=DEFAULT_TIMEOUT, default=None):
@@ -84,8 +135,20 @@ def win_timedinput(prompt='', timeout=DEFAULT_TIMEOUT, default=None):
         return default
     raise TimeoutOccurred
 
-
-if sys.platform.startswith("win"):
+if is_jupyter():
+    try:
+        import ipywidgets
+        import jupyter_ui_poll
+        timedinput = jupyter_timedinput
+    except ImportError:
+        import warnings
+        warnings.warn(
+            "For timeout support in Jupyter, you must install optional dependencies. "
+            "Run: %pip install ipywidgets jupyter-ui-poll. "
+            "Falling back to standard blocking input (no timeout)."
+        )
+        timedinput = input
+elif sys.platform.startswith("win"):
     timedinput = win_timedinput
 else:
     timedinput = posix_timedinput

--- a/timedinput/timedinput.py
+++ b/timedinput/timedinput.py
@@ -52,14 +52,18 @@ def jupyter_timedinput(prompt='', timeout=DEFAULT_TIMEOUT, default=None):
     done = [False]
 
     label = widgets.Label(value=prompt)
-    text = widgets.Text(placeholder='Type and press Enter...')
+    
+    # Add continuous_update=False so it only triggers on Enter
+    text = widgets.Text(placeholder='Type and press Enter...', continuous_update=False)
     box = widgets.VBox([label, text])
 
-    def on_submit(widget):
-        result[0] = widget.value
+    # The callback now receives a 'change' dictionary instead of the widget itself
+    def on_submit(change):
+        result[0] = change['new'] # Grab the newly typed text
         done[0] = True
 
-    text.on_submit(on_submit)
+    # Use observe to watch for changes to the 'value'
+    text.observe(on_submit, names='value')
     display(box)
 
     start_time = time.monotonic()

--- a/timedinput/timedinput.py
+++ b/timedinput/timedinput.py
@@ -135,6 +135,10 @@ def win_timedinput(prompt='', timeout=DEFAULT_TIMEOUT, default=None):
         return default
     raise TimeoutOccurred
 
+def _fallback_timedinput(prompt='', timeout=DEFAULT_TIMEOUT, default=None):
+    """Fallback that consumes extra arguments but acts like standard input"""
+    return input(prompt)
+
 if is_jupyter():
     try:
         import ipywidgets
@@ -147,7 +151,7 @@ if is_jupyter():
             "Run: %pip install ipywidgets jupyter-ui-poll. "
             "Falling back to standard blocking input (no timeout)."
         )
-        timedinput = input
+        timedinput = _fallback_timedinput
 elif sys.platform.startswith("win"):
     timedinput = win_timedinput
 else:


### PR DESCRIPTION
## Summary
This PR completely overhauls the module to introduce full support for Jupyter environments (JupyterLab, Classic Notebook, Google Colab, and VS Code Interactive). It successfully resolves the UI deadlock issue discussed in #1, stabilizing the core API for our official **v1.0.0** release.

Closes #1 

## The Problem
As identified by @kbocheltree in #1, standard Python `input()` and standard `time.sleep()` loops freeze the IPython main thread. Because Jupyter relies on that exact same thread to process UI interactions, standard `ipywidgets` (like the one attempted in the issue thread) would go deaf—the callback would never fire until the `while` loop timed out.

## The Solution
We successfully bypassed the Jupyter UI deadlock using `jupyter-ui-poll`, which allows the IPython kernel to "breathe" and process widget events without unblocking the synchronous Python script.

### Key Changes:
* **Jupyter Environment Detection:** Added a robust `is_jupyter()` check that accurately detects Jupyter, Colab, and standard IPython.
* **Synchronous Widget Fallback:** Implemented `jupyter_timedinput_sync` using `ipywidgets` and `jupyter_ui_poll` to provide a clean, non-blocking input field directly below the cell.
* **Modernized ipywidgets:** Replaced the deprecated `.on_submit()` with `.observe(..., names='value')` and `continuous_update=False` to ensure future compatibility.
* **Graceful Degradation:** Added a safe `_fallback_timedinput` wrapper. If a user runs this in Jupyter without the optional dependencies, they receive a helpful warning and a standard blocking `input()` prompt, preventing a `TypeError` crash.
* **Dependency Management:** Added optional `jupyter` dependencies (`ipywidgets` and `jupyter-ui-poll`) to `pyproject.toml`. Users can now install via `pip install timedinput[jupyter]`.

## Testing
- Verified standard POSIX behavior (no regressions).
- Verified standard Windows (`msvcrt`) behavior (no regressions).
- Verified Jupyter widget successfully intercepts `Enter` keystrokes and cleans up the UI upon timeout.
- Local `pytest` suite passing.

🚀 **Ready for v1.0.0 Release!**